### PR TITLE
Dynamic hostnames

### DIFF
--- a/R/on_load.R
+++ b/R/on_load.R
@@ -19,10 +19,10 @@ https://data.world"
 create_url <- function(subdomain) {
   environment <- Sys.getenv("DW_ENVIRONMENT")
   if (environment == "") {
-    return(paste("https://", subdomain, ".data.world/v0", sep = ""))
+    return(paste("https://", subdomain, ".data.world", sep = ""))
   }
 
-  paste("https://", subdomain, ".", environment, ".data.world/v0", sep = "")
+  paste("https://", subdomain, ".data.world", sep = "")
 }
 
 .onLoad <- function(libname, pkgname) {
@@ -30,7 +30,7 @@ create_url <- function(subdomain) {
   op.dwapi <- list(
     dwapi.api_url      = ifelse(
       Sys.getenv("DW_API_HOST") == "",
-      create_url("api"),
+      paste(create_url("api"), "/v0", sep = ""),
       Sys.getenv("DW_API_HOST")
     ),
     dwapi.query_url    = ifelse(

--- a/R/on_load.R
+++ b/R/on_load.R
@@ -16,12 +16,21 @@ permissions and limitations under the License.
 This product includes software developed at data.world, Inc.
 https://data.world"
 
+create_url <- function(subdomain) {
+  environment <- Sys.getenv("DW_ENVIRONMENT")
+  if (environment == "") {
+    return(paste("https://", subdomain, ".data.world/v0", sep=""))
+  }
+
+  return(paste("https://", subdomain, ".", environment, ".data.world/v0", sep=""))
+}
+
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dwapi <- list(
-    dwapi.api_url      = "https://api.data.world/v0",
-    dwapi.query_url    = "https://query.data.world",
-    dwapi.download_url = "https://download.data.world",
+    dwapi.api_url      = create_url("api"),
+    dwapi.query_url    = create_url("query"),
+    dwapi.download_url = create_url("download"),
     dwapi.cache_dir    = path.expand(file.path("~", ".dw", "cache"))
   )
   toset <- !(names(op.dwapi) %in% names(op))

--- a/R/on_load.R
+++ b/R/on_load.R
@@ -22,7 +22,7 @@ create_url <- function(subdomain) {
     return(paste("https://", subdomain, ".data.world/v0", sep=""))
   }
 
-  return(paste("https://", subdomain, ".", environment, ".data.world/v0", sep=""))
+  paste("https://", subdomain, ".", environment, ".data.world/v0", sep="")
 }
 
 .onLoad <- function(libname, pkgname) {

--- a/R/on_load.R
+++ b/R/on_load.R
@@ -19,22 +19,36 @@ https://data.world"
 create_url <- function(subdomain) {
   environment <- Sys.getenv("DW_ENVIRONMENT")
   if (environment == "") {
-    return(paste("https://", subdomain, ".data.world/v0", sep=""))
+    return(paste("https://", subdomain, ".data.world/v0", sep = ""))
   }
 
-  paste("https://", subdomain, ".", environment, ".data.world/v0", sep="")
+  paste("https://", subdomain, ".", environment, ".data.world/v0", sep = "")
 }
 
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dwapi <- list(
-    dwapi.api_url      = create_url("api"),
-    dwapi.query_url    = create_url("query"),
-    dwapi.download_url = create_url("download"),
+    dwapi.api_url      = ifelse(
+      Sys.getenv("DW_API_HOST") == "",
+      create_url("api"),
+      Sys.getenv("DW_API_HOST")
+    ),
+    dwapi.query_url    = ifelse(
+      Sys.getenv("DW_QUERY_HOST") == "",
+      create_url("query"),
+      Sys.getenv("DW_QUERY_HOST")
+    ),
+    dwapi.download_url = ifelse(
+      Sys.getenv("DW_DOWNLOAD_HOST") == "",
+      create_url("download"),
+      Sys.getenv("DW_DOWNLOAD_HOST")
+    ),
     dwapi.cache_dir    = path.expand(file.path("~", ".dw", "cache"))
   )
   toset <- !(names(op.dwapi) %in% names(op))
-  if (any(toset)) options(op.dwapi[toset])
+
+  if (any(toset))
+    options(op.dwapi[toset])
 
   invisible()
 }


### PR DESCRIPTION
Allow the use of environment specific API endpoints.

This is informed by the environment variable `DW_ENVIRONMENT` which can be set by adding `DW_ENVIRONMENT="the environment"` to the file `~/Renviron` (or maybe even setting it bash profile).

When the `DW_ENVIRONMENT` variable is undefined the api endpoints will fall back to the default.