### PR TITLE
Specify column types (obtained from dw table schema api) on read_csv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@
        - checkout
        - run: mkdir build build/reports build/dist
        - run: apt-get update && apt-get install -y qpdf
+       - run: Rscript -e 'install.packages(c("mockery", "covr", "lintr"), dependencies=TRUE)'
 
        - run:
            name: Install dwapi-r

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dwapi
 Title: A Client for 'data.world' REST API
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Mark", "DiMarco", email = "mark.dimarco@data.world", role = c("aut")),
     person("Rafael", "Pereira", email = "rafael.pereira@data.world", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# 0.3.1
+
+* `download_file_as_data_frame()` and `download_table_as_data_frame()` now use the data.world
+  table schema api to set the column types of the imported file/table data; callers can also control
+  this explicitly with the `col_types=` parameter to both functions
+
 # 0.3.0
 
 * functions that return data frames return them as tibbles

--- a/R/download_file.R
+++ b/R/download_file.R
@@ -40,7 +40,7 @@ download_file <-
     response <-
       httr::GET(
         url,
-        httr::add_headers(Authorization = sprintf("Bearer %s", auth_token())),
+        httr::add_headers(Authorization = paste0("Bearer ", auth_token())),
         httr::progress(),
         httr::user_agent(user_agent())
       )

--- a/R/download_file_as_data_frame.R
+++ b/R/download_file_as_data_frame.R
@@ -25,16 +25,15 @@ https://data.world"
 #' @examples
 #' \dontrun{
 #'   my_df <- dwapi::download_file_as_data_frame(
-#'     'user', 'dataset',
-#'     file_name = 'file.csv')
+#'     "user", "dataset",
+#'     file_name = "file.csv")
 #' }
 #' @export
 download_file_as_data_frame <-
-  function(owner_id, dataset_id, file_name) {
+  function(owner_id, dataset_id, file_name, col_types=NULL) {
     if (!endsWith(file_name, ".csv")) {
       stop("only support csv extension files.")
     }
-
     tmp_path <- tempfile(fileext = "csv")
     if (!dir.exists(dirname(tmp_path))) {
       dir.create(dirname(tmp_path), recursive = TRUE)
@@ -43,7 +42,10 @@ download_file_as_data_frame <-
       download_status <-
         dwapi::download_file(owner_id, dataset_id, file_name, tmp_path)
       if (download_status$category == "Success") {
-        readr::read_csv(tmp_path)
+        parse_downloaded_csv(
+          tmp_path, owner_id, dataset_id,
+          gsub(x = file_name, pattern = "(.+)\\.csv", replacement = "\\1"),
+          col_types)
       } else {
         stop(sprintf(
           "Failed to download %s (HTTP Error: %s)",
@@ -52,7 +54,36 @@ download_file_as_data_frame <-
         ))
       }
     },
-      finally = {
-        unlink(tmp_path, recursive = TRUE)
-      })
+    finally = {
+      unlink(tmp_path, recursive = TRUE)
+    })
   }
+
+parse_downloaded_csv <- function(csv, owner_id,
+                                 dataset_id, table_name, col_types = NULL) {
+  if (is.null(col_types)) {
+    ts <- get_table_schema(
+      owner_id, dataset_id,
+      table_name)
+    types <- purrr::map_chr(ts$fields, function(field_spec) {
+      rdf_type <- field_spec$rdf_type
+      rdf_type <- dplyr::case_when(
+        rdf_type == "http://www.w3.org/2001/XMLSchema#integer" ~ "i",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#string" ~ "c",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#boolean" ~ "l",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#decimal" ~ "d",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#float" ~ "d",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#double" ~ "d",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#dateTime" ~ "T",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#time" ~ "t",
+        rdf_type == "http://www.w3.org/2001/XMLSchema#date" ~ "D",
+        TRUE ~ "c"
+      )
+      rdf_type
+    })
+    types <- paste0(types, collapse = "")
+  } else {
+    types <- col_types
+  }
+  readr::read_csv(csv, col_types = types)
+}

--- a/R/download_file_as_data_frame.R
+++ b/R/download_file_as_data_frame.R
@@ -21,6 +21,9 @@ https://data.world"
 #' dataset or project
 #' @param dataset_id Dataset unique identifier
 #' @param file_name File name, including file extension.
+#' @param col_types column types specified in the same manner as the
+#' col_types parameter of readr::read_csv(), or pass NULL (the default) to
+#' detect column types automatically from the data.world table schema
 #' @return Data frame with the contents of CSV file.
 #' @examples
 #' \dontrun{
@@ -30,7 +33,7 @@ https://data.world"
 #' }
 #' @export
 download_file_as_data_frame <-
-  function(owner_id, dataset_id, file_name, col_types=NULL) {
+  function(owner_id, dataset_id, file_name, col_types = NULL) {
     if (!endsWith(file_name, ".csv")) {
       stop("only support csv extension files.")
     }

--- a/R/download_table_as_data_frame.R
+++ b/R/download_table_as_data_frame.R
@@ -21,6 +21,9 @@ https://data.world"
 #' dataset or project
 #' @param dataset_id Dataset unique identifier
 #' @param table_name Table name.
+#' @param col_types column types specified in the same manner as the
+#' col_types parameter of readr::read_csv(), or pass NULL (the default) to
+#' detect column types automatically from the data.world table schema
 #' @return Data frame with data from table.
 #' @seealso \code{\link{list_tables}}
 #' @examples
@@ -29,7 +32,7 @@ https://data.world"
 #' }
 #' @export
 download_table_as_data_frame <- function(owner_id, dataset_id,
-                                         table_name, col_types=NULL) {
+                                         table_name, col_types = NULL) {
   url <- sprintf(
     "%s/tables/%s/%s/%s/rows",
     getOption("dwapi.query_url"),

--- a/R/download_table_as_data_frame.R
+++ b/R/download_table_as_data_frame.R
@@ -28,7 +28,8 @@ https://data.world"
 #'   table_df <- dwapi::download_table_as_data_frame("user", "dataset", "table")
 #' }
 #' @export
-download_table_as_data_frame <- function(owner_id, dataset_id, table_name) {
+download_table_as_data_frame <- function(owner_id, dataset_id,
+                                         table_name, col_types=NULL) {
   url <- sprintf(
     "%s/tables/%s/%s/%s/rows",
     getOption("dwapi.query_url"),
@@ -47,7 +48,8 @@ download_table_as_data_frame <- function(owner_id, dataset_id, table_name) {
     text <- httr::content(x = response,
       as = "text",
       encoding = "UTF-8")
-    ret <- readr::read_csv(text)
+    ret <- parse_downloaded_csv(text, owner_id,
+                                dataset_id, table_name, col_types = col_types)
   } else {
     stop(
       sprintf(

--- a/R/get_table_schema.R
+++ b/R/get_table_schema.R
@@ -33,11 +33,10 @@ get_table_schema <- function(owner_id, dataset_id, table_name) {
     getOption("dwapi.query_url"),
     owner_id, dataset_id,
     table_name)
-  auth <- sprintf("Bearer %s", auth_token())
   response <- httr::GET(
     url,
-    httr::add_headers(`Content-Type` = "application/json",
-      Authorization = auth),
+    httr::add_headers(Authorization = paste0("Bearer ", auth_token())),
+    httr::progress(),
     httr::user_agent(user_agent())
   )
   if (response$status_code == 200) {

--- a/man/download_file_as_data_frame.Rd
+++ b/man/download_file_as_data_frame.Rd
@@ -4,7 +4,7 @@
 \alias{download_file_as_data_frame}
 \title{Download dataset file onto a data frame.}
 \usage{
-download_file_as_data_frame(owner_id, dataset_id, file_name)
+download_file_as_data_frame(owner_id, dataset_id, file_name, col_types = NULL)
 }
 \arguments{
 \item{owner_id}{User name and unique identifier of the creator of a
@@ -23,7 +23,7 @@ Download dataset file onto a data frame.
 \examples{
 \dontrun{
   my_df <- dwapi::download_file_as_data_frame(
-    'user', 'dataset',
-    file_name = 'file.csv')
+    "user", "dataset",
+    file_name = "file.csv")
 }
 }

--- a/man/download_file_as_data_frame.Rd
+++ b/man/download_file_as_data_frame.Rd
@@ -13,6 +13,10 @@ dataset or project}
 \item{dataset_id}{Dataset unique identifier}
 
 \item{file_name}{File name, including file extension.}
+
+\item{col_types}{column types specified in the same manner as the
+col_types parameter of readr::read_csv(), or pass NULL (the default) to
+detect column types automatically from the data.world table schema}
 }
 \value{
 Data frame with the contents of CSV file.

--- a/man/download_table_as_data_frame.Rd
+++ b/man/download_table_as_data_frame.Rd
@@ -18,6 +18,10 @@ dataset or project}
 \item{dataset_id}{Dataset unique identifier}
 
 \item{table_name}{Table name.}
+
+\item{col_types}{column types specified in the same manner as the
+col_types parameter of readr::read_csv(), or pass NULL (the default) to
+detect column types automatically from the data.world table schema}
 }
 \value{
 Data frame with data from table.

--- a/man/download_table_as_data_frame.Rd
+++ b/man/download_table_as_data_frame.Rd
@@ -4,7 +4,12 @@
 \alias{download_table_as_data_frame}
 \title{Download a dataset table onto a data frame.}
 \usage{
-download_table_as_data_frame(owner_id, dataset_id, table_name)
+download_table_as_data_frame(
+  owner_id,
+  dataset_id,
+  table_name,
+  col_types = NULL
+)
 }
 \arguments{
 \item{owner_id}{User name and unique identifier of the creator of a

--- a/tests/testthat/resources/query.data.world/file1.schema.json
+++ b/tests/testthat/resources/query.data.world/file1.schema.json
@@ -1,0 +1,25 @@
+{
+  "fields": [
+    {
+      "name": "a",
+      "title": "a",
+      "rdfType": "http://www.w3.org/2001/XMLSchema#integer"
+    },
+    {
+      "name": "b",
+      "title": "b",
+      "rdfType": "http://www.w3.org/2001/XMLSchema#integer"
+    },
+    {
+      "name": "c",
+      "title": "c",
+      "description": "Column c",
+      "rdfType": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "d",
+      "title": "d",
+      "rdfType": "http://www.w3.org/2001/XMLSchema#date"
+    }
+  ]
+}

--- a/tests/testthat/test_download_file_as_data_frame.R
+++ b/tests/testthat/test_download_file_as_data_frame.R
@@ -22,25 +22,71 @@ dw_test_that("downloadFileAsDataFrame making the correct HTTR request", {
   dataset <- "datasetid"
   response <- with_mock(
     `httr::GET` = function(url, header, progress, user_agent)  {
-      expect_equal(url,
-          paste(
-            "https://api.data.world/v0/file_download/",
-            "ownerid/datasetid/file1.csv",
-            sep = ""
-          ))
+      if (url == paste0(
+        "https://api.data.world/v0/file_download/",
+        "ownerid/datasetid/file1.csv"
+      )) {
+        expected <- success_message_with_content(
+          mock_response_path, "application/csv")
+      } else if (url == paste0(
+        "https://query.data.world/tables/ownerid/datasetid/file1/schema"
+      )) {
+        expected <- success_message_with_content(
+          "resources/query.data.world/file1.schema.json",
+          "application/json")
+      } else {
+        fail(paste0("Invalid url: ", url))
+      }
       expect_equal(header$headers[["Authorization"]], "Bearer API_TOKEN")
       expect_equal(user_agent$options$useragent, user_agent())
-      return(
-        success_message_with_content(
-          mock_response_path, "application/csv")
-      )
+      expected
     },
     `mime::guess_type` = function(...)
       NULL,
     dwapi::download_file_as_data_frame(owner, dataset,
       file_name = "file1.csv")
   )
-  expect <- readr::read_csv(mock_response_path)
+  expect <- readr::read_csv(mock_response_path, col_types = "iicD")
+  purrr::walk2(expect, response, function(expect_col, response_col) {
+    expect_equal(expect_col, response_col)
+  })
+  expect_equal(0,
+               length(base::setdiff(class(tibble::tibble()), class(response))))
+  expect_equal(0, ncol(dplyr::select_if(response, is.factor)))
+})
+
+dw_test_that("downloadFileAsDataFrame handles supplied col_types", {
+  mock_response_path <- "resources/file1.csv"
+  owner <- "ownerid"
+  dataset <- "datasetid"
+  response <- with_mock(
+    `httr::GET` = function(url, header, progress, user_agent)  {
+      if (url == paste0(
+        "https://api.data.world/v0/file_download/",
+        "ownerid/datasetid/file1.csv"
+      )) {
+        expected <- success_message_with_content(
+          mock_response_path, "application/csv")
+      } else if (url == paste0(
+        "https://query.data.world/tables/ownerid/datasetid/file1/schema"
+      )) {
+        expected <- success_message_with_content(
+          "resources/query.data.world/file1.schema.json",
+          "application/json")
+      } else {
+        fail(paste0("Invalid url: ", url))
+      }
+      expect_equal(header$headers[["Authorization"]], "Bearer API_TOKEN")
+      expect_equal(user_agent$options$useragent, user_agent())
+      expected
+    },
+    `mime::guess_type` = function(...)
+      NULL,
+    dwapi::download_file_as_data_frame(owner, dataset,
+                                       file_name = "file1.csv",
+                                       col_types = "idcD")
+  )
+  expect <- readr::read_csv(mock_response_path, col_types = "idcD")
   purrr::walk2(expect, response, function(expect_col, response_col) {
     expect_equal(expect_col, response_col)
   })

--- a/tests/testthat/test_download_table_as_data_frame.R
+++ b/tests/testthat/test_download_table_as_data_frame.R
@@ -22,15 +22,23 @@ dw_test_that("get_table_as_dataframe making the correct HTTR request", {
   dataset <- "datasetid"
   response <- with_mock(
     `httr::GET` = function(url, header, progress, user_agent)  {
-      expect_equal(
-        url, "https://query.data.world/tables/ownerid/datasetid/tableid/rows"
-      )
+      if (url == paste0(
+        "https://query.data.world/tables/ownerid/datasetid/tableid/rows"
+      )) {
+        expected <- success_message_with_content(
+          mock_response_path, "application/csv")
+      } else if (url == paste0(
+        "https://query.data.world/tables/ownerid/datasetid/tableid/schema"
+      )) {
+        expected <- success_message_with_content(
+          "resources/query.data.world/file1.schema.json",
+          "application/json")
+      } else {
+        fail(paste0("Invalid url: ", url))
+      }
       expect_equal(header$headers[["Authorization"]], "Bearer API_TOKEN")
       expect_equal(user_agent$options$useragent, user_agent())
-      return(
-        success_message_with_content(
-          mock_response_path, "application/csv")
-      )
+      expected
     },
     `mime::guess_type` = function(...)
       NULL,

--- a/tests/testthat/test_get_table_schema.R
+++ b/tests/testthat/test_get_table_schema.R
@@ -18,7 +18,7 @@ https://data.world"
 
 dw_test_that("get_table_schema making the correct HTTR request", {
   response <- with_mock(
-    `httr::GET` = function(url, header, user_agent)  {
+    `httr::GET` = function(url, header, progress, user_agent)  {
       expect_equal(url,
         "https://query.data.world/tables/ownerid/datasetid/tableid/schema")
       expect_equal(header$headers[["Authorization"]], "Bearer API_TOKEN")


### PR DESCRIPTION
https://dataworld.atlassian.net/browse/DEMO-33

This prevents errors that occur when null/blank values in csv files bork `readr::read_csv`'s ability to properly detect column types in the created R data frame.