### PR TITLE
Update README with new branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ intro_dataset <- dwapi::get_dataset(
 
 To get the current version from GitHub:
 ```R
-devtools::install_github("datadotworld/dwapi-r", build_vignettes = TRUE)
+devtools::install_github("datadotworld/dwapi-r", build_vignettes = TRUE, ref = "main")
 ```
 
 ## Configuration


### PR DESCRIPTION
`ref` defaults to `master` according to the documentation: https://www.rdocumentation.org/packages/devtools/versions/1.13.6/topics/install_github

When using `install_github` with the new branch name of `main`, we will need to include the `ref` manually.